### PR TITLE
fix: countdown not working on firefox

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,7 +8,7 @@ const year = document.getElementById("year");
 
 const currentYear = new Date().getFullYear();
 
-const newYearTime = new Date(`Januarry 01 ${currentYear + 1} 00:00:00`);
+const newYearTime = new Date(`January 01 ${currentYear + 1} 00:00:00`);
 
 // Set background Year
 year.innerText = currentYear + 1;


### PR DESCRIPTION
Countdown doesn't work on firefox because of typo in `newYearTime` variable

![image](https://user-images.githubusercontent.com/102903265/182667397-74b7faf1-291f-4323-8428-f418b6fb5897.png)
